### PR TITLE
fix: failing playlist test case

### DIFF
--- a/packages/castmill/lib/castmill/resources/media.ex
+++ b/packages/castmill/lib/castmill/resources/media.ex
@@ -31,13 +31,7 @@ defmodule Castmill.Resources.Media do
 
     belongs_to(:resource, Castmill.Resources.Resource, foreign_key: :resource_id)
 
-    many_to_many(
-      :files,
-      Castmill.Files.FilesMedias,
-      join_through: "files_medias",
-      join_keys: [media_id: :id, file_id: :id],
-      on_replace: :delete
-    )
+    has_many(:files, Castmill.Files.FilesMedias)
 
     timestamps()
   end

--- a/packages/castmill/test/castmill/playlists_test.exs
+++ b/packages/castmill/test/castmill/playlists_test.exs
@@ -331,8 +331,6 @@ defmodule Castmill.PlaylistsTest do
 
       assert Files.add_file_to_media(file.id, media.id, "default")
 
-      media = Repo.preload(media, :files)
-
       {:ok, _} =
         Resources.insert_item_into_playlist(playlist.id, nil, widget.id, 0, 1231, %{
           "image" => "#{media.id}"


### PR DESCRIPTION
Fixes the failing test case.

The issue is caused by us trying to read a File with the id of a FilesMedia. This initially works (pure luck though) since the id counter in postgres starts out at 1 for all tables in a fresh DB, but after some tests have run, different ids will be generated causing the test to fail.

I changed the many_to_many relationship in Media to has_,many. A FilesMedia certainly models a many_to_many relation between Media and File, but the relation beween Media and FilesMedia itself isn't many_to_many and we need read the FilesMedia in order to get the context property.

I hope I didn't get this totally "om bakfoten" :)
