### PR TITLE
Fix/delete cache entries if gone from integration

### DIFF
--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -80,6 +80,15 @@ export class Cache extends Dexie {
       }
     }
 
+    // Remove items from cache that are not in the integration
+    const items = await this.items.toArray();
+    for (const item of items) {
+      const exists = files.some((file) => file.url === item.cachedUrl);
+      if (!exists) {
+        await this.items.delete(item.url);
+      }
+    }
+
     // Iterate existing items and make sure they are up-to-date
     /*
     for (const itemType of Object.values(ItemType)) {

--- a/packages/cache/tests/cache.spec.ts
+++ b/packages/cache/tests/cache.spec.ts
@@ -172,9 +172,7 @@ describe('Cache', () => {
     const url = 'https://example.com/code.js';
     const storage = {
       init: vi.fn(),
-      listFiles: async () => [
-        { url, size: 12 },
-      ],
+      listFiles: async () => [{ url, size: 12 }],
       deleteFile: vi.fn(),
     } as unknown as StorageIntegration;
 
@@ -191,9 +189,9 @@ describe('Cache', () => {
       listFiles: async () => [],
       storeFile: vi.fn().mockResolvedValue({
         result: {
-          code: 'SUCCESS'
+          code: 'SUCCESS',
         },
-        item: { url, size: 12 }
+        item: { url, size: 12 },
       }),
       deleteFile: vi.fn(),
     } as unknown as StorageIntegration;

--- a/packages/cache/tests/resource-manager.spec.ts
+++ b/packages/cache/tests/resource-manager.spec.ts
@@ -39,46 +39,36 @@ describe('ResourceManager', () => {
 
       setFetchMock(code1);
 
+      // Create a cache with the initial code
       const storage = new StorageMockup({
         [uri]: code1,
       });
 
+      // Create a cache with the initial code
       const cache = new Cache(storage, 'test-resource', 10);
+      let needsRefreshCalled = false;
       const manager = new ResourceManager(cache);
 
       await manager.init();
 
+      // Get the code from the cache
       const { a } = await manager.import(uri);
       expect(a).to.be.eql(1);
-
-      manager.close();
-      cache.close();
 
       const code2 = 'export const a = 20;';
       setFetchMock(code2);
 
-      const storage2 = new StorageMockup({
-        [uri]: code2,
-      });
-
-      const cache2 = new Cache(storage2, 'test-resource', 10);
-      await cache2.init();
-
-      let needsRefreshCalled = false;
-      const manager2 = new ResourceManager(cache2, {
+      const manager2 = new ResourceManager(cache, {
         needsRefresh: () => {
           needsRefreshCalled = true;
         },
       });
 
       await manager2.init();
-
-      const result1 = await manager2.import(uri);
-      expect(result1.a).to.be.eql(20);
-
       manager2.close();
-      cache2.close();
+      cache.close();
 
+      // Check if the needsRefresh callback was called
       expect(needsRefreshCalled).to.be.true;
 
       global.fetch = originalFetch;


### PR DESCRIPTION
If a cached file is missing from the storage integration we should also remove it from the cache. This PR fixes this.

Resolves #58 