### PR TITLE
Fix/device recovery

### DIFF
--- a/packages/castmill/lib/castmill/devices.ex
+++ b/packages/castmill/lib/castmill/devices.ex
@@ -400,15 +400,25 @@ defmodule Castmill.Devices do
       # TODO: also check if auto_recovery is enabled
       if not is_nil(device) and
            device.last_ip == device_ip and
-           device.updated_at >= DateTime.from_unix(:os.system_time(:seconds) - 60 * 60, :second) do
+           device.updated_at <= hour_ago() do
         # Update device token
         token = generate_token()
-        device = update_device(device, %{token: token})
-        {device, token}
+        {:ok, device} = update_device(device, %{token: token})
+        device
       else
         Repo.rollback("Device not found or not eligible for recovery")
       end
     end)
+  end
+
+  @doc """
+    Returns the time one hour ago as a naive datetime.
+  """
+  defp hour_ago do
+    :os.system_time(:seconds)
+    |> Kernel.-(3600)
+    |> DateTime.from_unix!(:second)
+    |> DateTime.to_naive()
   end
 
   defp generate_token do

--- a/packages/castmill/lib/castmill/devices.ex
+++ b/packages/castmill/lib/castmill/devices.ex
@@ -411,9 +411,6 @@ defmodule Castmill.Devices do
     end)
   end
 
-  @doc """
-    Returns the time one hour ago as a naive datetime.
-  """
   defp hour_ago do
     :os.system_time(:seconds)
     |> Kernel.-(3600)

--- a/packages/castmill/lib/castmill_web/controllers/devices/device_json.ex
+++ b/packages/castmill/lib/castmill_web/controllers/devices/device_json.ex
@@ -17,6 +17,19 @@ defmodule CastmillWeb.DeviceJSON do
     %{data: data(device)}
   end
 
+  @doc """
+  Renders the recovery information for a device.
+  """
+  def recover(%{device: device}) do
+    %{
+      data: %{
+        id: device.id,
+        name: device.name,
+        token: device.token
+      }
+    }
+  end
+
   defp data(%Device{} = device) do
     %{
       id: device.id,

--- a/packages/device/src/classes/device.ts
+++ b/packages/device/src/classes/device.ts
@@ -336,6 +336,21 @@ export class Device extends EventEmitter {
     if (pincodeResponse.status === 201) {
       const { data } = await pincodeResponse.json();
       return data.pincode;
+    } else if (pincodeResponse.status === 200) {
+      // Device was already registered, and we got the token to recover it.
+      const { data } = await pincodeResponse.json();
+
+      const credentials = {
+        device: {
+          id: data.id,
+          name: data.name,
+          token: data.token,
+        },
+      };
+      await this.integration.storeCredentials!(JSON.stringify(credentials));
+
+      // Refresh the page to initialize the player with the new credentials.
+      window.location.reload();
     } else {
       throw new Error(`Invalid status ${pincodeResponse.status}`);
     }


### PR DESCRIPTION
Recover devices if the token was lost. Also fixes a bug caused by comparing `device.updated_at` which is a `NaiveDateTime` with a `DateTime`. The type mismatch caused the logic limiting device recovery to once per hour to fail. This has now been fixed. 