### PR TITLE
fix(castmill): use utc_timestamps instead of native

### DIFF
--- a/packages/castmill/config/config.exs
+++ b/packages/castmill/config/config.exs
@@ -100,6 +100,9 @@ config :castmill, Oban,
 # Configure gettext
 config :castmill, CastmillWeb.Gettext, default_locale: "en"
 
+# Configure Ecto
+config :castmill, Castmill.Repo, migration_timestamps: [type: :utc_datetime]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/packages/castmill/lib/castmill/accounts/access_token.ex
+++ b/packages/castmill/lib/castmill/accounts/access_token.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Accounts.AccessToken do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   schema "access_tokens" do

--- a/packages/castmill/lib/castmill/accounts/signup.ex
+++ b/packages/castmill/lib/castmill/accounts/signup.ex
@@ -2,7 +2,7 @@
 # Signups are used to generate signup links that can then be used to create a
 # new user account using Passkey authentication.
 defmodule Castmill.Accounts.SignUp do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @primary_key {:id, Ecto.UUID, autogenerate: true}

--- a/packages/castmill/lib/castmill/accounts/user.ex
+++ b/packages/castmill/lib/castmill/accounts/user.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Accounts.User do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/accounts/user_credential.ex
+++ b/packages/castmill/lib/castmill/accounts/user_credential.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Accounts.UserCredential do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @primary_key {:id, :string, []}

--- a/packages/castmill/lib/castmill/accounts/user_token.ex
+++ b/packages/castmill/lib/castmill/accounts/user_token.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Accounts.UserToken do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Query
   alias Castmill.Accounts.UserToken
 

--- a/packages/castmill/lib/castmill/devices/device.ex
+++ b/packages/castmill/lib/castmill/devices/device.ex
@@ -1,7 +1,7 @@
 defmodule Castmill.Devices.Device do
   @behaviour Castmill.Behaviour.Filterable
 
-  use Ecto.Schema
+  use Castmill.Schema
 
   import Ecto.Changeset
   import Ecto.Query, warn: false
@@ -31,7 +31,7 @@ defmodule Castmill.Devices.Device do
   schema "devices" do
     field(:info, :map)
     field(:last_ip, :string)
-    field(:last_online, :naive_datetime)
+    field(:last_online, :utc_datetime)
     field(:online, :boolean, default: false)
     field(:loc_lat, :float)
     field(:loc_long, :float)

--- a/packages/castmill/lib/castmill/devices/devices_channels.ex
+++ b/packages/castmill/lib/castmill/devices/devices_channels.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Devices.DevicesChannels do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @primary_key false

--- a/packages/castmill/lib/castmill/devices/devices_events.ex
+++ b/packages/castmill/lib/castmill/devices/devices_events.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Devices.DevicesEvents do
-  use Ecto.Schema
+  use Castmill.Schema
 
   import Ecto.Changeset
   import Ecto.Query, warn: false

--- a/packages/castmill/lib/castmill/devices/devices_registrations.ex
+++ b/packages/castmill/lib/castmill/devices/devices_registrations.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Devices.DevicesRegistrations do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @primary_key false

--- a/packages/castmill/lib/castmill/files/file.ex
+++ b/packages/castmill/lib/castmill/files/file.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Files.File do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/files/files_medias.ex
+++ b/packages/castmill/lib/castmill/files/files_medias.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Files.FilesMedias do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @derive {Jason.Encoder, only: [:id, :file_id, :media_id, :context]}

--- a/packages/castmill/lib/castmill/networks/network.ex
+++ b/packages/castmill/lib/castmill/networks/network.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Networks.Network do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/networks/networks_admins.ex
+++ b/packages/castmill/lib/castmill/networks/networks_admins.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Networks.NetworksAdmins do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   schema "networks_admins" do

--- a/packages/castmill/lib/castmill/networks/networks_users.ex
+++ b/packages/castmill/lib/castmill/networks/networks_users.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Networks.NetworksUsers do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   schema "networks_users" do

--- a/packages/castmill/lib/castmill/organizations/organization.ex
+++ b/packages/castmill/lib/castmill/organizations/organization.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Organizations.Organization do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/organizations/organization_users_access.ex
+++ b/packages/castmill/lib/castmill/organizations/organization_users_access.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Organizations.OrganizationsUsersAccess do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @primary_key false

--- a/packages/castmill/lib/castmill/organizations/organizations_invitations.ex
+++ b/packages/castmill/lib/castmill/organizations/organizations_invitations.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Organizations.OrganizationsInvitation do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/organizations/organizations_users.ex
+++ b/packages/castmill/lib/castmill/organizations/organizations_users.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Organizations.OrganizationsUsers do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/quotas/plans.ex
+++ b/packages/castmill/lib/castmill/quotas/plans.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Quotas.Plan do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/quotas/plans_organizations.ex
+++ b/packages/castmill/lib/castmill/quotas/plans_organizations.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Quotas.PlansOrganizations do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/quotas/plans_quotas.ex
+++ b/packages/castmill/lib/castmill/quotas/plans_quotas.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Quotas.PlansQuotas do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/quotas/quotas_networks.ex
+++ b/packages/castmill/lib/castmill/quotas/quotas_networks.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Quotas.QuotasNetworks do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/quotas/quotas_organizations.ex
+++ b/packages/castmill/lib/castmill/quotas/quotas_organizations.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Quotas.QuotasOrganizations do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/resources/channel.ex
+++ b/packages/castmill/lib/castmill/resources/channel.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Resources.Channel do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/resources/channel_entry.ex
+++ b/packages/castmill/lib/castmill/resources/channel_entry.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Resources.ChannelEntry do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @derive {Jason.Encoder,

--- a/packages/castmill/lib/castmill/resources/media.ex
+++ b/packages/castmill/lib/castmill/resources/media.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Resources.Media do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/resources/playlist.ex
+++ b/packages/castmill/lib/castmill/resources/playlist.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Resources.Playlist do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/resources/playlist_item.ex
+++ b/packages/castmill/lib/castmill/resources/playlist_item.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Resources.PlaylistItem do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   @derive {Jason.Encoder,

--- a/packages/castmill/lib/castmill/resources/resource.ex
+++ b/packages/castmill/lib/castmill/resources/resource.ex
@@ -1,6 +1,6 @@
 # DEPRECATED: This module is not used anymore, but it's kept here until we remove all references to it.
 defmodule Castmill.Resources.Resource do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
 
   # Todo maybe change the name to "shareable-resource" to make more explicit the

--- a/packages/castmill/lib/castmill/schema.ex
+++ b/packages/castmill/lib/castmill/schema.ex
@@ -1,0 +1,8 @@
+defmodule Castmill.Schema do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      @timestamps_opts [type: :utc_datetime]
+    end
+  end
+end

--- a/packages/castmill/lib/castmill/teams/team.ex
+++ b/packages/castmill/lib/castmill/teams/team.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.Team do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/teams/team_invitation.ex
+++ b/packages/castmill/lib/castmill/teams/team_invitation.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.Invitation do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   alias __MODULE__
 

--- a/packages/castmill/lib/castmill/teams/teams_medias.ex
+++ b/packages/castmill/lib/castmill/teams/teams_medias.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.TeamsMedias do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/teams/teams_playlists.ex
+++ b/packages/castmill/lib/castmill/teams/teams_playlists.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.TeamsPlaylists do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/teams/teams_resources.ex
+++ b/packages/castmill/lib/castmill/teams/teams_resources.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.TeamsResources do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/teams/teams_users.ex
+++ b/packages/castmill/lib/castmill/teams/teams_users.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Teams.TeamsUsers do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/widgets/transition.ex
+++ b/packages/castmill/lib/castmill/widgets/transition.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Widgets.Transition do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/widgets/widget.ex
+++ b/packages/castmill/lib/castmill/widgets/widget.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Widgets.Widget do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 

--- a/packages/castmill/lib/castmill/widgets/widget_config.ex
+++ b/packages/castmill/lib/castmill/widgets/widget_config.ex
@@ -1,5 +1,5 @@
 defmodule Castmill.Widgets.WidgetConfig do
-  use Ecto.Schema
+  use Castmill.Schema
   import Ecto.Changeset
   import Ecto.Query, warn: false
 
@@ -18,7 +18,7 @@ defmodule Castmill.Widgets.WidgetConfig do
     field(:version, :integer, default: 1)
 
     # TODO: rename to requested_at (for consistency with updated_at and inserted_at)
-    field(:last_request_at, :naive_datetime, default: nil)
+    field(:last_request_at, :utc_datetime, default: nil)
 
     belongs_to(:widget, Castmill.Widgets.Widget)
     belongs_to :playlist_item, Castmill.Resources.PlaylistItem, foreign_key: :playlist_item_id

--- a/packages/castmill/priv/repo/migrations/20230324145946_create_widgets_config.exs
+++ b/packages/castmill/priv/repo/migrations/20230324145946_create_widgets_config.exs
@@ -9,7 +9,7 @@ defmodule Castmill.Repo.Migrations.CreateWidgetsConfig do
       add(:options, :map, default: %{})
       add(:data, :map, default: %{})
 
-      add(:last_request_at, :naive_datetime, default: nil)
+      add(:last_request_at, :utc_datetime, default: nil)
 
       add(:widget_id, references(:widgets, column: "id", on_delete: :delete_all), null: false)
 

--- a/packages/castmill/priv/repo/migrations/20230324152704_create_devices.exs
+++ b/packages/castmill/priv/repo/migrations/20230324152704_create_devices.exs
@@ -11,7 +11,7 @@ defmodule Castmill.Repo.Migrations.CreateDevices do
       add :last_ip, :string
       add :token_hash, :string
       add :online, :boolean
-      add :last_online, :naive_datetime
+      add :last_online, :utc_datetime
       add :user_agent, :string
       add :timezone, :string
       add :loc_lat, :float

--- a/packages/castmill/test/castmill/devices_test.exs
+++ b/packages/castmill/test/castmill/devices_test.exs
@@ -166,11 +166,7 @@ defmodule Castmill.DevicesTest do
       assert {:error, _} = Devices.recover_device(device.hardware_id, device.last_ip)
 
       # Setting the updated_at to an hour ago
-      hour_ago =
-        :os.system_time(:seconds)
-        |> Kernel.-(3600)
-        |> DateTime.from_unix!(:second)
-        |> DateTime.to_naive()
+      hour_ago = DateTime.utc_now() |> DateTime.add(-1, :hour)
 
       from(d in Devices.Device, where: d.id == ^device.id)
       |> Repo.update_all(set: [updated_at: hour_ago])


### PR DESCRIPTION
Use utc_datetime everywhere in Ecto. In order to set this globally I created a custom Schema implementation with this setting and then used it everywhere. Resolves #72 