### PR TITLE
fix(dashboard): show video preview in medias

### DIFF
--- a/packages/castmill/lib/castmill/addons/medias/components/media-details.tsx
+++ b/packages/castmill/lib/castmill/addons/medias/components/media-details.tsx
@@ -1,10 +1,11 @@
-import { createSignal, createEffect, Show } from 'solid-js';
+import { createSignal, createEffect } from 'solid-js';
 
 import { Button, FormItem } from '@castmill/ui-common';
 
 import { BsCheckLg, BsX } from 'solid-icons/bs';
 import { JsonMedia } from '@castmill/player';
 import { MediasUpdate } from '../services/medias.service';
+import { MediaPreview } from './media-preview';
 
 export const MediaDetails = (props: {
   media: JsonMedia;
@@ -75,19 +76,7 @@ export const MediaDetails = (props: {
           </FormItem>
         </div>
 
-        <div class="preview">
-          <Show
-            when={props.media.files['preview']}
-            fallback={<div> Placeholder ...</div>}
-          >
-            <div
-              class="image"
-              style={{
-                'background-image': `url(${props.media.files['preview'].uri})`,
-              }}
-            ></div>
-          </Show>
-        </div>
+        <MediaPreview media={props.media} />
 
         <div class="actions">
           <Button

--- a/packages/castmill/lib/castmill/addons/medias/components/media-preview.tsx
+++ b/packages/castmill/lib/castmill/addons/medias/components/media-preview.tsx
@@ -1,6 +1,12 @@
 import { Show } from 'solid-js';
 import { JsonMedia } from '@castmill/player';
 
+/**
+ * Props for the MediaPreview component.
+ * 
+ * @property media - The media object containing details about the preview, including files and metadata.
+ * @property previewClass - An optional CSS class to apply custom styling to the preview container.
+ */
 interface MediaPreviewProps {
   media: JsonMedia;
   previewClass?: string;

--- a/packages/castmill/lib/castmill/addons/medias/components/media-preview.tsx
+++ b/packages/castmill/lib/castmill/addons/medias/components/media-preview.tsx
@@ -1,0 +1,42 @@
+import { Show } from 'solid-js';
+import { JsonMedia } from '@castmill/player';
+
+interface MediaPreviewProps {
+  media: JsonMedia;
+  previewClass?: string;
+}
+
+export const MediaPreview = (props: MediaPreviewProps) => {
+  // Check if the preview file is a video based on mimetype
+  const isVideoPreview = () => {
+    const previewFile = props.media.files['preview'];
+    return previewFile && previewFile.mimetype && previewFile.mimetype.startsWith('video/');
+  };
+
+  return (
+    <div class={`preview ${props.previewClass || ''}`}>
+      <Show
+        when={props.media.files['preview']}
+        fallback={<div class="placeholder">No preview available</div>}
+      >
+        <Show
+          when={isVideoPreview()}
+          fallback={
+            <div
+              class="image"
+              style={{
+                'background-image': `url(${props.media.files['preview'].uri})`,
+              }}
+            ></div>
+          }
+        >
+          <video 
+            src={props.media.files['preview'].uri} 
+            controls 
+            class="video-preview"
+          ></video>
+        </Show>
+      </Show>
+    </div>
+  );
+};

--- a/packages/castmill/lib/castmill/addons/medias/components/medias.scss
+++ b/packages/castmill/lib/castmill/addons/medias/components/medias.scss
@@ -18,7 +18,6 @@
 
 .medias-modal {
   width: 60%;
-  height: 60%;
 
   .info {
     font-size: 0.8em;
@@ -50,12 +49,22 @@
 
     .preview {
       display: flex;
-      justify-content: flex-start;
+      justify-content: center;
       align-items: center;
-      width: 95%;
-      flex: 1;
+      width: 100%;
+      max-height: 45vh;
+      min-height: 30vh;
+      height: auto;
+      flex: 0 1 auto;
       overflow: hidden;
-      margin: 0;
+      margin: 0 0 0.5em 0;
+      border: 1px solid #333;
+      border-radius: 4px;
+      
+      .placeholder {
+        color: #888;
+        font-style: italic;
+      }
 
       .image {
         width: 100%;
@@ -67,6 +76,12 @@
         justify-content: center;
         align-items: center;
         overflow: hidden;
+      }
+      
+      .video-preview {
+        max-width: 100%;
+        object-fit: contain;
+        margin: auto;
       }
     }
   }


### PR DESCRIPTION
Adds a video preview to video medias

Before | After
---|---
<img width="745" alt="image" src="https://github.com/user-attachments/assets/105d338c-563d-4a50-aa06-11ef0a8e9f54" /> | <img width="734" alt="image" src="https://github.com/user-attachments/assets/cc1c5ef1-5c94-47d7-8e72-38562f937596" />