### PR TITLE
fix: send Bearer token in media upload XHR requests

### DIFF
--- a/packages/castmill/lib/castmill/accounts/email_templates/already_registered.html.eex
+++ b/packages/castmill/lib/castmill/accounts/email_templates/already_registered.html.eex
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Account Already Exists — Castmill™</title>
+  <!--[if mso]>
+  <style type="text/css">
+    body, table, td {font-family: Arial, Helvetica, sans-serif !important;}
+  </style>
+  <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color: #f4f4f4;">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+        <!-- Main Container -->
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 600px;">
+
+          <!-- Header with Logo -->
+          <tr>
+            <td align="center" style="padding: 40px 40px 30px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border-radius: 8px 8px 0 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td align="center">
+                    <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; letter-spacing: -0.5px;">
+                      Castmill™
+                    </h1>
+                    <p style="margin: 10px 0 0 0; color: #e0e7ff; font-size: 14px; font-weight: 400;">
+                      Digital Signage Platform
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Main Content -->
+          <tr>
+            <td style="padding: 40px 40px 30px 40px;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td>
+                    <h2 style="margin: 0 0 20px 0; color: #1a1a1a; font-size: 24px; font-weight: 600; line-height: 1.3;">
+                      You already have an account
+                    </h2>
+                    <p style="margin: 0 0 20px 0; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                      Hi <strong><%= @email %></strong>,
+                    </p>
+                    <p style="margin: 0 0 20px 0; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                      Someone (hopefully you) tried to sign up for Castmill™ using this email address. However, an account with this email already exists.
+                    </p>
+                    <p style="margin: 0 0 30px 0; color: #4a5568; font-size: 16px; line-height: 1.6;">
+                      If this was you, you can simply log in using the link below. If you've lost your passkey or are having trouble logging in, use the credential recovery option on the login page.
+                    </p>
+                  </td>
+                </tr>
+
+                <!-- Call-to-Action Button -->
+                <tr>
+                  <td align="center" style="padding: 10px 0 30px 0;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td align="center" style="border-radius: 6px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+                          <a href="<%= @login_url %>" target="_blank" style="display: inline-block; padding: 16px 40px; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: 600; border-radius: 6px; letter-spacing: 0.3px;">
+                            Go to Login
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Security Notice -->
+                <tr>
+                  <td style="padding: 20px; background-color: #f7fafc; border-left: 4px solid #667eea; border-radius: 4px;">
+                    <p style="margin: 0; color: #4a5568; font-size: 14px; line-height: 1.5;">
+                      <strong>🔒 Security Notice:</strong> If you didn't attempt to sign up, you can safely ignore this email. Your existing account has not been affected.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding: 30px 40px 40px 40px; background-color: #f9fafb; border-radius: 0 0 8px 8px; border-top: 1px solid #e2e8f0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 15px 0; color: #718096; font-size: 14px; line-height: 1.5;">
+                      <strong>Need help?</strong> Visit our
+                      <a href="https://castmill.com/support" style="color: #667eea; text-decoration: none;">support center</a>
+                      or contact us at
+                      <a href="mailto:support@castmill.com" style="color: #667eea; text-decoration: none;">support@castmill.com</a>
+                    </p>
+                    <p style="margin: 0 0 10px 0; color: #a0aec0; font-size: 12px; line-height: 1.5;">
+                      © <%= @year %> Castmill AB. All rights reserved.
+                    </p>
+                    <p style="margin: 0; color: #a0aec0; font-size: 12px; line-height: 1.5;">
+                      This is an automated message, please do not reply to this email.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/packages/castmill/lib/castmill/accounts/email_templates/already_registered.text.eex
+++ b/packages/castmill/lib/castmill/accounts/email_templates/already_registered.text.eex
@@ -1,0 +1,32 @@
+========================================
+CASTMILL™ - Digital Signage Platform
+========================================
+
+You already have an account
+
+Hi <%= @email %>,
+
+Someone (hopefully you) tried to sign up for Castmill™ using this email address. However, an account with this email already exists.
+
+If this was you, you can simply log in by visiting:
+
+<%= @login_url %>
+
+If you've lost your passkey or are having trouble logging in, use the credential recovery option on the login page.
+
+----------------------------------------
+
+🔒 SECURITY NOTICE:
+If you didn't attempt to sign up, you can safely ignore this email. Your existing account has not been affected.
+
+----------------------------------------
+
+Need help?
+Visit our support center: https://castmill.com/support
+Contact us: support@castmill.com
+
+© <%= @year %> Castmill AB. All rights reserved.
+
+This is an automated message, please do not reply to this email.
+
+========================================

--- a/packages/castmill/lib/castmill/accounts/user_notifier.ex
+++ b/packages/castmill/lib/castmill/accounts/user_notifier.ex
@@ -21,6 +21,20 @@ defmodule Castmill.Accounts.UserNotifier do
     [:assigns]
   )
 
+  EEx.function_from_file(
+    :defp,
+    :render_already_registered_html,
+    Path.join(@templates_dir, "already_registered.html.eex"),
+    [:assigns]
+  )
+
+  EEx.function_from_file(
+    :defp,
+    :render_already_registered_text,
+    Path.join(@templates_dir, "already_registered.text.eex"),
+    [:assigns]
+  )
+
   # Delivers the email using the application mailer.
   defp deliver(recipient, subject, body, opts \\ []) do
     context = Keyword.get(opts, :context, "user_notifier.text")
@@ -185,6 +199,28 @@ defmodule Castmill.Accounts.UserNotifier do
     deliver_with_html(
       signup.email,
       "Complete Your Castmill Signup",
+      text_body,
+      html_body
+    )
+  end
+
+  @doc """
+  Deliver a notice to an existing user who tried to sign up again.
+  Informs them they already have an account and directs them to log in.
+  """
+  def deliver_already_registered_notice(email, dashboard_uri) do
+    assigns = %{
+      email: email,
+      login_url: dashboard_uri,
+      year: DateTime.utc_now().year
+    }
+
+    html_body = render_already_registered_html(assigns)
+    text_body = render_already_registered_text(assigns)
+
+    deliver_with_html(
+      email,
+      "Castmill™ — You Already Have an Account",
       text_body,
       html_body
     )

--- a/packages/castmill/lib/castmill/addons/medias/components/upload.test.tsx
+++ b/packages/castmill/lib/castmill/addons/medias/components/upload.test.tsx
@@ -37,6 +37,7 @@ class MockXMLHttpRequest {
 
   open = vi.fn();
   send = vi.fn();
+  setRequestHeader = vi.fn();
 
   constructor() {
     MockXMLHttpRequest.instances.push(this);
@@ -154,5 +155,35 @@ describe('UploadComponent', () => {
     MockXMLHttpRequest.instances[0].triggerAbort();
 
     await waitFor(() => expect(onUploadComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it('sets Authorization header with Bearer token from localStorage', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) =>
+        key === 'castmill_auth_token' ? 'test-token-123' : null
+      ),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+
+    render(() => (
+      <UploadComponent baseUrl="http://test.local" organizationId="org-1" />
+    ));
+
+    setFilesOnInput([new File(['data'], 'image.png', { type: 'image/png' })]);
+    const uploadButton = screen.getByRole('button', { name: 'Upload' });
+
+    fireEvent.click(uploadButton);
+    await waitFor(() => expect(uploadButton).toBeDisabled());
+
+    expect(MockXMLHttpRequest.instances).toHaveLength(1);
+    const xhr = MockXMLHttpRequest.instances[0];
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith(
+      'Authorization',
+      'Bearer test-token-123'
+    );
   });
 });

--- a/packages/castmill/lib/castmill/addons/medias/components/upload.tsx
+++ b/packages/castmill/lib/castmill/addons/medias/components/upload.tsx
@@ -196,7 +196,12 @@ export const UploadComponent = (props: UploadComponentProps) => {
         `${props.baseUrl}/dashboard/organizations/${props.organizationId}/medias`,
         true
       );
-      xhr.withCredentials = true;
+
+      // Attach Bearer token for authentication (cookies are no longer used)
+      const token = localStorage.getItem('castmill_auth_token');
+      if (token) {
+        xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+      }
 
       xhr.upload.onprogress = (event) => {
         if (event.lengthComputable) {

--- a/packages/castmill/lib/castmill_web/controllers/signup_controller.ex
+++ b/packages/castmill/lib/castmill_web/controllers/signup_controller.ex
@@ -114,44 +114,20 @@ defmodule CastmillWeb.SignUpController do
             |> put_status(:forbidden)
             |> json(%{status: :error, msg: "This network requires an invitation to sign up"})
           else
-            challenge = SessionUtils.new_challenge()
-            params = %{"email" => email, "challenge" => challenge, "network_id" => network_id}
+            # Check if a user with this email already exists
+            case Accounts.get_user_by_email(email) do
+              %Castmill.Accounts.User{} ->
+                # User already exists — send a different email explaining this,
+                # but return the same response to prevent email enumeration.
+                UserNotifier.deliver_already_registered_notice(email, origin)
 
-            case Accounts.create_signup(params) do
-              {:ok, signup} ->
-                case UserNotifier.deliver_signup_instructions(signup, origin) do
-                  {:ok, _email} ->
-                    # Serialize the signup struct
-                    signup_data = %{
-                      id: signup.id,
-                      email: signup.email,
-                      inserted_at: signup.inserted_at,
-                      updated_at: signup.updated_at,
-                      challenge: signup.challenge,
-                      status_message: signup.status_message
-                    }
-
-                    conn
-                    |> put_status(:created)
-                    |> json(%{status: :ok, signup: signup_data})
-
-                  {:error, reason} ->
-                    # Optionally, you might want to delete the signup if email delivery fails
-                    # Accounts.delete_signup(signup)
-
-                    conn
-                    |> put_status(:unprocessable_entity)
-                    |> json(%{
-                      status: :error,
-                      msg: "Failed to send email",
-                      error: inspect(reason)
-                    })
-                end
-
-              {:error, _changeset} ->
                 conn
-                |> put_status(:unprocessable_entity)
-                |> json(%{status: :error})
+                |> put_status(:created)
+                |> json(%{status: :ok, signup: %{email: email}})
+
+              nil ->
+                # New user — proceed with normal signup flow
+                create_signup_and_send_email(conn, email, network_id, origin)
             end
           end
 
@@ -160,6 +136,45 @@ defmodule CastmillWeb.SignUpController do
           |> put_status(:unprocessable_entity)
           |> json(%{status: :error, msg: "Network not found"})
       end
+    end
+  end
+
+  defp create_signup_and_send_email(conn, email, network_id, origin) do
+    challenge = SessionUtils.new_challenge()
+    params = %{"email" => email, "challenge" => challenge, "network_id" => network_id}
+
+    case Accounts.create_signup(params) do
+      {:ok, signup} ->
+        case UserNotifier.deliver_signup_instructions(signup, origin) do
+          {:ok, _email} ->
+            # Serialize the signup struct
+            signup_data = %{
+              id: signup.id,
+              email: signup.email,
+              inserted_at: signup.inserted_at,
+              updated_at: signup.updated_at,
+              challenge: signup.challenge,
+              status_message: signup.status_message
+            }
+
+            conn
+            |> put_status(:created)
+            |> json(%{status: :ok, signup: signup_data})
+
+          {:error, reason} ->
+            conn
+            |> put_status(:unprocessable_entity)
+            |> json(%{
+              status: :error,
+              msg: "Failed to send email",
+              error: inspect(reason)
+            })
+        end
+
+      {:error, _changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{status: :error})
     end
   end
 

--- a/packages/dashboard/src/components/signup/signup.tsx
+++ b/packages/dashboard/src/components/signup/signup.tsx
@@ -179,9 +179,9 @@ const SignUp: Component = () => {
     });
 
     if (!result.ok) {
-      toast.error(
-        t('signup.errors.signupFailed', { error: result.statusText })
-      );
+      const data = await result.json().catch(() => ({}));
+      const serverMessage = data.message || data.msg || result.statusText;
+      toast.error(t('signup.errors.signupFailed', { error: serverMessage }));
     } else {
       toast.success('Account created successfully!');
       navigate('/');

--- a/packages/dashboard/src/i18n/locales/ar.json
+++ b/packages/dashboard/src/i18n/locales/ar.json
@@ -564,7 +564,8 @@
     "errors": {
       "authenticationFailed": "فشل المصادقة. يرجى المحاولة مرة أخرى.",
       "userBlocked": "تم حظر حسابك. السبب: {{reason}}",
-      "organizationBlocked": "تم حظر مؤسستك. السبب: {{reason}}"
+      "organizationBlocked": "تم حظر مؤسستك. السبب: {{reason}}",
+      "signupFailed": "تعذر بدء التسجيل. يرجى المحاولة لاحقاً."
     }
   },
   "credentialRecovery": {
@@ -1040,7 +1041,7 @@
       "couldNotCreateCredential": "تعذر إنشاء بيانات الاعتماد",
       "couldNotGetPublicKey": "تعذر الحصول على المفتاح العام",
       "invalidCredential": "بيانات اعتماد غير صالحة",
-      "signupFailed": "حدث خطأ أثناء التسجيل، اتصل بالدعم. الخطأ: {{error}}"
+      "signupFailed": "فشل التسجيل: {{error}}. يرجى المحاولة مرة أخرى أو الاتصال بالدعم."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/de.json
+++ b/packages/dashboard/src/i18n/locales/de.json
@@ -693,7 +693,8 @@
     "errors": {
       "authenticationFailed": "Authentifizierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
       "userBlocked": "Ihr Konto wurde gesperrt. Grund: {{reason}}",
-      "organizationBlocked": "Ihre Organisation wurde gesperrt. Grund: {{reason}}"
+      "organizationBlocked": "Ihre Organisation wurde gesperrt. Grund: {{reason}}",
+      "signupFailed": "Registrierung konnte nicht gestartet werden. Bitte versuchen Sie es später erneut."
     }
   },
   "credentialRecovery": {
@@ -729,7 +730,7 @@
       "couldNotCreateCredential": "Anmeldedaten konnten nicht erstellt werden",
       "couldNotGetPublicKey": "Öffentlicher Schlüssel konnte nicht abgerufen werden",
       "invalidCredential": "Ungültige Anmeldedaten",
-      "signupFailed": "Bei der Registrierung ist ein Fehler aufgetreten, kontaktieren Sie den Support. FEHLER: {{error}}"
+      "signupFailed": "Registrierung fehlgeschlagen: {{error}}. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/en.json
+++ b/packages/dashboard/src/i18n/locales/en.json
@@ -706,7 +706,8 @@
     "errors": {
       "authenticationFailed": "Authentication failed. Please try again.",
       "userBlocked": "Your account has been blocked. Reason: {{reason}}",
-      "organizationBlocked": "Your organization has been blocked. Reason: {{reason}}"
+      "organizationBlocked": "Your organization has been blocked. Reason: {{reason}}",
+      "signupFailed": "Could not start signup. Please try again later."
     }
   },
   "credentialRecovery": {
@@ -742,7 +743,7 @@
       "couldNotCreateCredential": "Could not create credential",
       "couldNotGetPublicKey": "Could not get public key",
       "invalidCredential": "Invalid credential",
-      "signupFailed": "Something went wrong when signing up, contact support. ERROR: {{error}}"
+      "signupFailed": "Signup failed: {{error}}. Please try again or contact support."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/es.json
+++ b/packages/dashboard/src/i18n/locales/es.json
@@ -565,7 +565,8 @@
     "errors": {
       "authenticationFailed": "Error de autenticación. Por favor, inténtalo de nuevo.",
       "userBlocked": "Tu cuenta ha sido bloqueada. Razón: {{reason}}",
-      "organizationBlocked": "Tu organización ha sido bloqueada. Razón: {{reason}}"
+      "organizationBlocked": "Tu organización ha sido bloqueada. Razón: {{reason}}",
+      "signupFailed": "No se pudo iniciar el registro. Inténtalo más tarde."
     }
   },
   "credentialRecovery": {
@@ -748,7 +749,7 @@
       "couldNotCreateCredential": "No se pudo crear la credencial",
       "couldNotGetPublicKey": "No se pudo obtener la clave pública",
       "invalidCredential": "Credencial inválida",
-      "signupFailed": "Algo salió mal al registrarse, contacta a soporte. ERROR: {{error}}"
+      "signupFailed": "Error en el registro: {{error}}. Inténtalo de nuevo o contacta con soporte."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/fr.json
+++ b/packages/dashboard/src/i18n/locales/fr.json
@@ -564,7 +564,8 @@
     "errors": {
       "authenticationFailed": "Échec de l'authentification. Veuillez réessayer.",
       "userBlocked": "Votre compte a été bloqué. Raison : {{reason}}",
-      "organizationBlocked": "Votre organisation a été bloquée. Raison : {{reason}}"
+      "organizationBlocked": "Votre organisation a été bloquée. Raison : {{reason}}",
+      "signupFailed": "Impossible de démarrer l'inscription. Veuillez réessayer plus tard."
     }
   },
   "credentialRecovery": {
@@ -1052,7 +1053,7 @@
       "couldNotCreateCredential": "Impossible de créer les identifiants",
       "couldNotGetPublicKey": "Impossible d'obtenir la clé publique",
       "invalidCredential": "Identifiants invalides",
-      "signupFailed": "Une erreur s'est produite lors de l'inscription, contactez le support. ERREUR : {{error}}"
+      "signupFailed": "Échec de l'inscription : {{error}}. Veuillez réessayer ou contacter le support."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/ja.json
+++ b/packages/dashboard/src/i18n/locales/ja.json
@@ -564,7 +564,8 @@
     "errors": {
       "authenticationFailed": "認証に失敗しました。もう一度お試しください。",
       "userBlocked": "あなたのアカウントはブロックされています。理由: {{reason}}",
-      "organizationBlocked": "あなたの組織はブロックされています。理由: {{reason}}"
+      "organizationBlocked": "あなたの組織はブロックされています。理由: {{reason}}",
+      "signupFailed": "サインアップを開始できませんでした。後でもう一度お試しください。"
     }
   },
   "credentialRecovery": {
@@ -1041,7 +1042,7 @@
       "couldNotCreateCredential": "認証情報を作成できませんでした",
       "couldNotGetPublicKey": "公開鍵を取得できませんでした",
       "invalidCredential": "無効な認証情報です",
-      "signupFailed": "サインアップ中に問題が発生しました。サポートにお問い合わせください。エラー：{{error}}"
+      "signupFailed": "サインアップに失敗しました：{{error}}。もう一度お試しいただくか、サポートにお問い合わせください。"
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/ko.json
+++ b/packages/dashboard/src/i18n/locales/ko.json
@@ -564,7 +564,8 @@
     "errors": {
       "authenticationFailed": "인증에 실패했습니다. 다시 시도해 주세요.",
       "userBlocked": "귀하의 계정이 차단되었습니다. 사유: {{reason}}",
-      "organizationBlocked": "귀하의 조직이 차단되었습니다. 사유: {{reason}}"
+      "organizationBlocked": "귀하의 조직이 차단되었습니다. 사유: {{reason}}",
+      "signupFailed": "가입을 시작할 수 없습니다. 나중에 다시 시도해 주세요."
     }
   },
   "credentialRecovery": {
@@ -1040,7 +1041,7 @@
       "couldNotCreateCredential": "자격 증명을 생성할 수 없습니다",
       "couldNotGetPublicKey": "공개 키를 가져올 수 없습니다",
       "invalidCredential": "유효하지 않은 자격 증명",
-      "signupFailed": "회원가입 중 문제가 발생했습니다. 지원팀에 문의하세요. 오류: {{error}}"
+      "signupFailed": "회원가입 실패: {{error}}. 다시 시도하거나 지원팀에 문의하세요."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/sv.json
+++ b/packages/dashboard/src/i18n/locales/sv.json
@@ -559,7 +559,8 @@
     "errors": {
       "authenticationFailed": "Autentiseringen misslyckades. Försök igen.",
       "userBlocked": "Ditt konto har blockerats. Anledning: {{reason}}",
-      "organizationBlocked": "Din organisation har blockerats. Anledning: {{reason}}"
+      "organizationBlocked": "Din organisation har blockerats. Anledning: {{reason}}",
+      "signupFailed": "Kunde inte starta registreringen. Försök igen senare."
     }
   },
   "credentialRecovery": {
@@ -1035,7 +1036,7 @@
       "couldNotCreateCredential": "Kunde inte skapa inloggningsuppgift",
       "couldNotGetPublicKey": "Kunde inte hämta publik nyckel",
       "invalidCredential": "Ogiltig inloggningsuppgift",
-      "signupFailed": "Något gick fel vid registrering, kontakta support. FEL: {{error}}"
+      "signupFailed": "Registreringen misslyckades: {{error}}. Försök igen eller kontakta support."
     }
   },
   "search": {

--- a/packages/dashboard/src/i18n/locales/zh.json
+++ b/packages/dashboard/src/i18n/locales/zh.json
@@ -564,7 +564,8 @@
     "errors": {
       "authenticationFailed": "身份验证失败。请重试。",
       "userBlocked": "您的账户已被封禁。原因：{{reason}}",
-      "organizationBlocked": "您的组织已被封禁。原因：{{reason}}"
+      "organizationBlocked": "您的组织已被封禁。原因：{{reason}}",
+      "signupFailed": "无法开始注册。请稍后再试。"
     }
   },
   "credentialRecovery": {
@@ -1040,7 +1041,7 @@
       "couldNotCreateCredential": "无法创建凭据",
       "couldNotGetPublicKey": "无法获取公钥",
       "invalidCredential": "凭据无效",
-      "signupFailed": "注册时出现问题，请联系支持。错误：{{error}}"
+      "signupFailed": "注册失败：{{error}}。请重试或联系支持。"
     }
   },
   "search": {


### PR DESCRIPTION
The media upload component used XMLHttpRequest directly (for progress tracking) and relied on xhr.withCredentials (cookies) for auth. After migrating to bearer-token-based authentication, uploads failed with "Invalid token format" because no Authorization header was sent.

- Read token from localStorage and set Authorization header on XHR
- Remove obsolete xhr.withCredentials = true
- Add test verifying Bearer token is attached to upload requests