### PR TITLE
feat: serve legacy adapter on /legacy route

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "build:platforms:webos": "cd packages/platforms/webos-player && yarn build",
     "build:platforms:electron": "cd packages/platforms/electron-player && yarn build",
     "build:platforms:legacy": "cd packages/platforms/legacy-adapter-player && yarn build",
+    "build:platforms:legacy:server": "cd packages/platforms/legacy-adapter-player && yarn build:server",
     "build:platforms": "yarn run build:platforms:android && yarn run build:platforms:webos && yarn run build:platforms:electron && yarn run build:platforms:legacy",
     "build:all": "yarn run build:ui-common && yarn run build:cache && yarn run build:player && yarn run build:device && yarn run build:dashboard && yarn run build:widged && yarn run build:platforms",
-    "build:server": "yarn run build:ui-common && yarn run build:cache && yarn run build:player && yarn run build:device",
+    "build:server": "yarn run build:ui-common && yarn run build:cache && yarn run build:player && yarn run build:device && yarn run build:platforms:legacy:server",
     "check-translations": "cd packages/dashboard && yarn check-translations",
     "prepare": "husky"
   },

--- a/packages/castmill/.gitignore
+++ b/packages/castmill/.gitignore
@@ -39,6 +39,9 @@ castmill-*.tar
 # Ignore built dashboard SPA (produced by vite build)
 /priv/static/dashboard/
 
+# Ignore built legacy adapter player SPA (produced by vite build:server)
+/priv/static/legacy/
+
 # Ignore runtime directories (user uploads, uploaded widget assets)
 /priv/static/medias/
 /priv/static/widget_assets/

--- a/packages/castmill/lib/castmill_web.ex
+++ b/packages/castmill/lib/castmill_web.ex
@@ -18,7 +18,7 @@ defmodule CastmillWeb do
   """
 
   def static_paths,
-    do: ~w(assets fonts images favicon.ico castmill_favicon.png robots.txt medias widgets)
+    do: ~w(assets fonts images favicon.ico castmill_favicon.png robots.txt medias widgets legacy)
 
   def router do
     quote do

--- a/packages/castmill/lib/castmill_web/controllers/legacy_player_controller.ex
+++ b/packages/castmill/lib/castmill_web/controllers/legacy_player_controller.ex
@@ -4,8 +4,14 @@ defmodule CastmillWeb.LegacyPlayerController do
   def index(conn, _params) do
     index_path = Application.app_dir(:castmill, "priv/static/legacy/index.html")
 
-    conn
-    |> put_resp_content_type("text/html")
-    |> send_file(200, index_path)
+    if File.exists?(index_path) do
+      conn
+      |> put_resp_content_type("text/html")
+      |> send_file(200, index_path)
+    else
+      conn
+      |> put_resp_content_type("text/html")
+      |> send_resp(404, "Legacy player not available")
+    end
   end
 end

--- a/packages/castmill/lib/castmill_web/controllers/legacy_player_controller.ex
+++ b/packages/castmill/lib/castmill_web/controllers/legacy_player_controller.ex
@@ -1,0 +1,11 @@
+defmodule CastmillWeb.LegacyPlayerController do
+  use CastmillWeb, :controller
+
+  def index(conn, _params) do
+    index_path = Application.app_dir(:castmill, "priv/static/legacy/index.html")
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_file(200, index_path)
+  end
+end

--- a/packages/castmill/lib/castmill_web/router.ex
+++ b/packages/castmill/lib/castmill_web/router.ex
@@ -101,6 +101,8 @@ defmodule CastmillWeb.Router do
 
   # The legacy adapter player is a standalone public application.
   scope "/", CastmillWeb do
+    pipe_through(:device)
+
     get("/legacy", LegacyPlayerController, :index)
   end
 

--- a/packages/castmill/lib/castmill_web/router.ex
+++ b/packages/castmill/lib/castmill_web/router.ex
@@ -99,6 +99,11 @@ defmodule CastmillWeb.Router do
     get("/", DeviceController, :home)
   end
 
+  # The legacy adapter player is a standalone public application.
+  scope "/", CastmillWeb do
+    get("/legacy", LegacyPlayerController, :index)
+  end
+
   pipeline :register do
     plug(:accepts, ["json"])
   end

--- a/packages/castmill/test/castmill_web/controllers/legacy_player_controller_test.exs
+++ b/packages/castmill/test/castmill_web/controllers/legacy_player_controller_test.exs
@@ -1,0 +1,40 @@
+defmodule CastmillWeb.LegacyPlayerControllerTest do
+  use CastmillWeb.ConnCase, async: false
+
+  @legacy_static_path Application.app_dir(:castmill, "priv/static/legacy")
+  @index_html "<!doctype html><title>Legacy Player</title>"
+  @asset_contents "console.log('legacy player');"
+
+  setup do
+    backup_path = "#{@legacy_static_path}.backup-#{System.unique_integer([:positive])}"
+    existing_bundle? = File.exists?(@legacy_static_path)
+
+    if existing_bundle? do
+      File.rename!(@legacy_static_path, backup_path)
+    end
+
+    File.mkdir_p!(Path.join(@legacy_static_path, "assets"))
+    File.write!(Path.join(@legacy_static_path, "index.html"), @index_html)
+    File.write!(Path.join(@legacy_static_path, "assets/player.js"), @asset_contents)
+
+    on_exit(fn ->
+      File.rm_rf!(@legacy_static_path)
+
+      if existing_bundle? do
+        File.rename!(backup_path, @legacy_static_path)
+      end
+    end)
+
+    :ok
+  end
+
+  test "serves the legacy player entry document", %{conn: conn} do
+    assert get(conn, "/legacy") |> response(200) == @index_html
+    assert get(conn, "/legacy/") |> response(200) == @index_html
+  end
+
+  test "serves legacy static assets and does not fall back for missing files", %{conn: conn} do
+    assert get(conn, "/legacy/assets/player.js") |> response(200) == @asset_contents
+    assert get(conn, "/legacy/assets/missing.js") |> response(404)
+  end
+end

--- a/packages/platforms/legacy-adapter-player/Readme.md
+++ b/packages/platforms/legacy-adapter-player/Readme.md
@@ -9,6 +9,8 @@ The **Castmill Legacy Adapter** is a bridge designed to support legacy Castmill 
 - [Overview](#overview)
 - [Features](#features)
 - [Usage](#usage)
+- [Serving from Castmill](#serving-from-castmill)
+- [Migration rollout](#migration-rollout)
 - [Configuration](#configuration)
 - [Contributing](#contributing)
 - [License](#license)
@@ -17,12 +19,13 @@ The **Castmill Legacy Adapter** is a bridge designed to support legacy Castmill 
 
 ## Overview
 
-The Castmill Legacy Adapter serves at the endpoint where the old Castmill application was hosted. It ensures that legacy players, which rely on the original APIs, continue to function without modification. Internally, it proxies or adapts these requests to the new Castmill player, enabling a seamless experience for both legacy and new clients.
+The Castmill Legacy Adapter enables old Castmill Electron and Android players to connect to a new Castmill server without changing those players. It preserves the legacy player APIs and adapts them to the modern Castmill player and server.
 
 ### Key Purpose:
 
-- Maintain compatibility with legacy Electron and Android Castmill players.
-- Integrate the modern Castmill player without disrupting existing workflows.
+- Allow existing legacy Castmill players to connect to new Castmill deployments.
+- Maintain compatibility with the Electron and Android legacy player APIs.
+- Enable migration to the modern player without disrupting existing workflows.
 
 ---
 
@@ -31,16 +34,44 @@ The Castmill Legacy Adapter serves at the endpoint where the old Castmill applic
 - **Legacy API Support**: Implements the APIs required by legacy players.
 - **Modern Player Integration**: Uses the new Castmill player internally.
 - **Seamless Transition**: Allows legacy embeds to function as expected without updates.
-- **Endpoint Compatibility**: Serves on the original Castmill hosting URL.
+- **Castmill Server Deployment**: Served at `/legacy` by the Castmill Phoenix server.
 - **Configurable Base URL**: Easily configure the default base URL using environment variables.
 
 ---
 
 ## Usage
 
-1. Deploy the adapter to the same endpoint where the old Castmill was hosted.
-2. Verify that legacy players point to this endpoint for their API interactions.
+1. Build the Castmill server image or run `yarn build:server` from the repository root.
+2. Open the adapter at `https://<castmill-server>/legacy`.
 3. Test the functionality of legacy players to ensure smooth operation with the new Castmill player.
+
+---
+
+## Serving from Castmill
+
+The production Castmill build runs this workspace's `build:server` script. It generates
+the adapter in `packages/castmill/priv/static/legacy/`, which Phoenix serves as:
+
+| URL                | Purpose                                       |
+| ------------------ | --------------------------------------------- |
+| `/legacy`          | Legacy adapter entry page                     |
+| `/legacy/assets/*` | Adapter JavaScript and other generated assets |
+
+Use `yarn build` for a standalone workspace build, or `yarn build:server` to generate
+the files for the Castmill server. The server-targeted build uses `/legacy/` as its Vite
+base URL, so generated assets load from the same Castmill server.
+
+---
+
+## Migration rollout
+
+During migration, the old Castmill player server proxies migrated players to `/legacy`
+on the new Castmill Phoenix server. This allows individual legacy players to use the new
+server while the old player domain continues to serve players that have not migrated.
+
+After all players have migrated, point the old player domain at the new Phoenix server.
+The Phoenix server must then serve the same legacy adapter content for requests received
+through that domain as it does for `/legacy`.
 
 ---
 

--- a/packages/platforms/legacy-adapter-player/index.html
+++ b/packages/platforms/legacy-adapter-player/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="shortcut icon" type="image/ico" href="/src/assets/favicon.ico" />
+    <link rel="shortcut icon" type="image/ico" href="/favicon.ico" />
     <title>Castmill Legacy Adapter</title>
   </head>
   <body>

--- a/packages/platforms/legacy-adapter-player/package.json
+++ b/packages/platforms/legacy-adapter-player/package.json
@@ -11,6 +11,7 @@
     "start": "vite",
     "dev": "vite -d",
     "build": "vite build",
+    "build:server": "vite build --base=/legacy/ --outDir=../../castmill/priv/static/legacy --emptyOutDir",
     "serve": "vite preview",
     "test": "vitest run"
   },


### PR DESCRIPTION
Serve the legacy player adapter from the Castmill Phoenix server at  /legacy .

 - Builds the adapter into Phoenix static assets with  /legacy/  asset URLs
 - Adds public  /legacy  entry routing and static asset serving
 - Documents legacy-player migration, proxying, and eventual domain cutover
 - Adds focused coverage for the entry page and assets